### PR TITLE
위키 모드

### DIFF
--- a/inputter.js
+++ b/inputter.js
@@ -423,7 +423,16 @@ $(document).ready(function() {
         for (var i = 0; i < text.length; i++) {
             if (text[i] in puaconvtable) {
                 marktext += '<mark>' + text[i] + '</mark>';
-                newtext += puaconvtable[text[i]];
+                var newchar = puaconvtable[text[i]];
+                if ($('#mediawiki').prop('checked') && (
+                    newchar.charCodeAt(0) >= 0x1100 &&
+                    newchar.charCodeAt(0) <= 0x1112 &&
+                    newchar.charCodeAt(1) >= 0x1161 &&
+                    newchar.charCodeAt(1) <= 0x1175
+                )) {
+                    newchar = newchar[0] + '<!---->' + newchar.substring(1);
+                }
+                newtext += newchar;
             } else {
                 marktext += text[i];
                 newtext += text[i];
@@ -434,6 +443,7 @@ $(document).ready(function() {
     }
     var input = $('.convert-input');
     var backdrop = $('.backdrop');
+    $('#mediawiki').change(convert);
     input.on('input change keyup ready', convert);
     input.on('scroll', function(event) {
     	var scrollTop = input.scrollTop();

--- a/inputter.js
+++ b/inputter.js
@@ -414,26 +414,27 @@ $(document).ready(function() {
     });
 
     // CONVERTING
-    var output = $('.convert-output');
+    function convert(event) {
+        var output = $('.convert-output');
+        var highlights = $('.highlights');
+        text = input.val().normalize();
+        newtext = '';
+        marktext = '';
+        for (var i = 0; i < text.length; i++) {
+            if (text[i] in puaconvtable) {
+                marktext += '<mark>' + text[i] + '</mark>';
+                newtext += puaconvtable[text[i]];
+            } else {
+                marktext += text[i];
+                newtext += text[i];
+            }
+        }
+        highlights.html(marktext + '<br><br><br>');
+        output.val(newtext);
+    }
     var input = $('.convert-input');
-    var highlights = $('.highlights');
-    var backdrop = $('.backdrop')
-    input.on('input change keyup ready', function(event) {
-    	text = input.val().normalize();
-    	newtext = '';
-    	marktext = '';
-    	for (var i = 0; i < text.length; i++) {
-    		if (text[i] in puaconvtable) {
-    			marktext += '<mark>' + text[i] + '</mark>';
-    			newtext += puaconvtable[text[i]];
-    		} else {
-    			marktext += text[i];
-    			newtext += text[i];
-    		}
-    	}
-    	highlights.html(marktext + '<br><br><br>');
-    	output.val(newtext);
-    });
+    var backdrop = $('.backdrop');
+    input.on('input change keyup ready', convert);
     input.on('scroll', function(event) {
     	var scrollTop = input.scrollTop();
 		backdrop.scrollTop(scrollTop);

--- a/oko.html
+++ b/oko.html
@@ -142,7 +142,10 @@
             </div>
         </section>
         <section>
-            <div class="sectiontitle">한양 PUA → 첫가끝 코드 변환</div>
+            <div class="sectiontitle">
+                한양 PUA → 첫가끝 코드 변환
+                (<label><input id="mediawiki" type="checkbox">MediaWiki 모드</label>)
+            </div>
             <div class="container convert">
                 <div class="backdrop convert">
                     <div class="highlights">


### PR DESCRIPTION
안녕하세요. 저는 [위키문헌](https://ko.wikisource.org/)이라는 곳에서 조선시대 한글 자료 등을 편집하고 있는데, 옛한글 변환기를 찾다가 이 페이지를 알게 되어서 아주 유용하게 쓰고 있습니다.

한가지 아쉬운 점이 있어서 기능을 고친 게 있는데, 혹시 반영해주실 수 있을까 해서 이 글을 쓰게 됐습니다.

많은 인터넷 환경에서 텍스트를 저장할 때 정규화를 거치는데, 그 과정에서 합쳐질 수 있는 글자가 합쳐지는 경우가 있습니다. 예를 들어 옛한글의 경우 첫가끝 코드로 `ㅈㅕㆁ`이라고 쓰면 `ㅈ`와 `ㅕ`가 합쳐져서 `져ㆁ`이 되는 것입니다.

이것은 제가 알기로는 유니코드에서 의도된 동작이며, 원래대로라면 `져ㆁ`가 있어도 `ㆁ`이 끝소리(HANGUL JONGSEONG YESIEUNG U+11F0)라면 글꼴이나 렌더러가 알아서 한 글자로 합쳐서 보여줘야 합니다. 하지만 그런 기능을 구현해놓은 사례를 저는 지금까지 한 번도 본 적이 없습니다.

따라서 실제로는 초성과 중성이 합쳐지는 것을 피해야 합니다. 위키백과나 위키문헌에서 쓰는 MediaWiki의 경우 초성과 중성 사이에 `<!---->`같은 의미없는 문구를 넣어서 합쳐지는 것을 피하고 있습니다. 그래서 한양 PUA에서 첫가끝 코드로 변환할 때 이것을 자동으로 해주는 기능이 필요했던 것입니다.

![image](https://user-images.githubusercontent.com/787236/35466469-817d60d0-0347-11e8-9158-8987f8201729.png)

코드를 확인해 주시고, 혹시 괜찮으시다면 반영해 주시면 정말 감사드리겠습니다.